### PR TITLE
Accept period after hop number for mtr reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@ submitButton.addEventListener("click", async function() {
   for (const line of text.split("\n")) {
     let r1, r2;
     if (
-      (r1=/^ *(\d+) /.exec(line)) !== null && (
+      (r1=/^ *(\d+)[ \.]/.exec(line)) !== null && (
         (r2=/\(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\)/.exec(line)) !== null ||
         (r2=/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/.exec(line)) !== null ||
         (r2=/\((?:[0-9a-f]{1,4}::?){1,7}[0-9a-f]{1,4}\)/.exec(line)) !== null ||


### PR DESCRIPTION
Fixes #8

Users would need to use something like `mtr -wrb`
`-r` to print a report
`-b` shows IP addresses
`-w` to let the report be as wide as necessary to not truncate IP addresses