### PR TITLE
Cross the antimeridian if it would be shorter

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,33 @@ let db = {};
 function draw(hosts) {
   hosts = hosts.filter(host => host.ip in db);
 
+  // draw lines
+  for (let i=1; i < hosts.length; i++) {
+    const host1 = hosts[i-1];
+    const host2 = hosts[i];
+    // console.log("drawing line between", [ db[host1.ip], db[host2.ip] ]);
+    // Would it be shorter to cross the antimeridian?
+    if (Math.abs(db[host1.ip][0] - db[host2.ip][0]) > 180) {
+      // We are affecting db so that the created markers will have the adjusted coordinates,
+      //  which will result in the bounds being correct to reposition the map view properly.
+      db[host1.ip][0] += db[host1.ip][0] < 0 ? 360 : -360;
+    }
+    const line = new ol.layer.Vector({
+      source: new ol.source.Vector({
+        features: [
+          new ol.Feature({
+            geometry: new ol.geom.LineString([
+              ol.proj.fromLonLat(db[host1.ip]),
+              ol.proj.fromLonLat(db[host2.ip]),
+            ])
+          })
+        ]
+      }),
+    });
+    map.addLayer(line);
+    markers.push(line);
+  }
+
   // draw markers
   const bounds = [];
   for (let i=0; i < hosts.length; i++) {
@@ -201,34 +228,10 @@ function draw(hosts) {
   // reposition map view
   if (bounds.length > 0) {
     const extent = ol.extent.boundingExtent(bounds);
-    // setTimeout is used since otherwise the animation blocks rendering of the markers and lines
-    setTimeout(() => {
-      map.getView().fit(extent, {
-        padding: [15, 15, 15, 15],
-        duration: 500,
-      });
+    map.getView().fit(extent, {
+      padding: [15, 15, 15, 15],
+      duration: 500,
     });
-  }
-
-  // draw lines
-  for (let i=1; i < hosts.length; i++) {
-    const host1 = hosts[i-1];
-    const host2 = hosts[i];
-    // console.log("drawing line between", [ db[host1.ip], db[host2.ip] ]);
-    const line = new ol.layer.Vector({
-      source: new ol.source.Vector({
-        features: [
-          new ol.Feature({
-            geometry: new ol.geom.LineString([
-              ol.proj.fromLonLat(db[host1.ip]),
-              ol.proj.fromLonLat(db[host2.ip]),
-            ])
-          })
-        ]
-      }),
-    });
-    map.addLayer(line);
-    markers.push(line);
   }
 }
 


### PR DESCRIPTION
I suppose there are some cases where this doesn't represent the actual routing of undersea cables, but I'd bet that in most cases it's more accurate.

Before:
<img width="1540" height="1000" alt="Screenshot 2025-12-10 at 17-15-59 Traceroute mapper" src="https://github.com/user-attachments/assets/a22ecd40-5e2a-404d-9546-b4385c0be2f8" />
After:
<img width="1540" height="1000" alt="Screenshot 2025-12-10 at 17-15-48 Traceroute mapper" src="https://github.com/user-attachments/assets/13b7b0be-ea42-40e6-a36a-46fb8c9ad130" />

Most of the lines changed were just moving the line creation to before the marker creation, so that we can put the markers at coordinates adjusted to allow the map reposition to work properly.
This also allowed the removal of setTimeout from the map reposition.